### PR TITLE
fix(marp-build): Move fonts to nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,8 @@
           self.marp-cli
           pkgs.google-chrome
           pkgs.jekyll
+        ];
+        nativeBuildInputs = [
           pkgs.noto-fonts-cjk-sans
         ];
         src = ./.;


### PR DESCRIPTION
PDFに何も書かれていないという異常があったため、このPRを提出する。
多分これで直ると思う。

## 症状
[make-my-ssg.pdf](https://github.com/user-attachments/files/17000316/make-my-ssg.pdf)
ここにアタッチしたようなファイルが、`nix build`にて出力された。見ての通り、何も書かれていなかった。

## 解決策
色々と`flake.nix`を編集してみたら、フォントは`nativeBuildInputs`に入れるべきだとなった。

## 環境
`nix-shell -p nix-info --run "nix-info -m"`
```txt
 - system: `"x86_64-linux"`
 - host os: `Linux 6.6.47, NixOS, 24.11 (Vicuna), 24.11.20240827.a6292e3`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.18.5`
 - nixpkgs: `/nix/store/h1v7aq3k9wy0i5l53cirm7kka7fsipji-source`
```